### PR TITLE
fix crash when status object is missing (#1)

### DIFF
--- a/mast/timeline.go
+++ b/mast/timeline.go
@@ -128,6 +128,9 @@ func (timeline *Timeline) Load() error {
 	oldestNotificationIndex := len(notifications) - 1
 	for i := oldestStatusIndex; i >= 0; i-- {
 		status := statuses[i]
+		if status == nil {
+			continue
+		}
 		var notification *mastodon.Notification = nil
 
 		if oldestNotificationIndex >= i {


### PR DESCRIPTION
There were cases (at minimum) when notifications did not have statuses. Rather than address in all the various sources of statuses I went with one final check after they had been assembled.