### PR TITLE
Command history view

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ Retoot/boost toot with ID *11*
 `help` \
 Show this help
 
+`history` \
+Show command history
+
 `bye` \
 Goodbye!
 

--- a/cli/cmdCmd.go
+++ b/cli/cmdCmd.go
@@ -18,12 +18,13 @@ var cmdCmd = &cobra.Command{
 	Long:  "Run command directly from the command line.",
 	Run: func(cmd *cobra.Command, args []string) {
 		timeline := mast.NewTimeline(MastodonClient)
-		cmdReturn, loadTimeline := mast.CmdProcessor(
+		result := mast.CmdProcessor(
 			&timeline,
 			strings.Join(args, " "),
 			mast.TriggerCLI,
 		)
 
+		cmdReturn, _, loadTimeline := result.Decompose()
 		switch cmdReturn {
 		case mast.CodeOk:
 			if loadTimeline == true {

--- a/mast/cmd.go
+++ b/mast/cmd.go
@@ -211,13 +211,13 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecu
 		timeline.Switch(TimelineUser, &timelineOptions)
 		return CmdExecutionResult{CodeOk, nil, true}
 	case "t", "toot":
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityPublic)) //false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityPublic))
 	case "tp", "tootprivate":
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityPrivate)) //, false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityPrivate))
 	case "tu", "tootunlisted":
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityUnlisted)) //, false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityUnlisted))
 	case "td", "tootdirect":
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityUnlisted)) //, false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityUnlisted))
 	case "re", "reply":
 		if trigger != TriggerTUI {
 			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
@@ -228,7 +228,7 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecu
 			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityPublic)) //, false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityPublic))
 	case "rep", "replyprivate":
 		if trigger != TriggerTUI {
 			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
@@ -239,7 +239,7 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecu
 			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityPrivate)) // false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityPrivate))
 	case "reu", "replyunlisted":
 		if trigger != TriggerTUI {
 			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
@@ -250,7 +250,7 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecu
 			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityUnlisted)) // false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityUnlisted))
 	case "red", "replydirect":
 		if trigger != TriggerTUI {
 			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
@@ -261,7 +261,7 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecu
 			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityDirect)) // false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityDirect))
 	case "rt", "retoot", "boost":
 		if trigger != TriggerTUI {
 			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
@@ -272,7 +272,7 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecu
 			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdBoost(timeline, tootId)) //, false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdBoost(timeline, tootId))
 	case "ut", "unretoot", "unboost":
 		if trigger != TriggerTUI {
 			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
@@ -283,7 +283,7 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecu
 			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdUnboost(timeline, tootId)) // false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdUnboost(timeline, tootId))
 	case "fav":
 		if trigger != TriggerTUI {
 			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
@@ -294,7 +294,7 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecu
 			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdFav(timeline, tootId)) // false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdFav(timeline, tootId))
 	case "unfav":
 		if trigger != TriggerTUI {
 			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
@@ -305,7 +305,7 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecu
 			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdUnfav(timeline, tootId)) //, false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdUnfav(timeline, tootId))
 	case "open":
 		if trigger != TriggerTUI {
 			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
@@ -316,7 +316,7 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecu
 			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdOpen(timeline, tootId)) //, false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdOpen(timeline, tootId))
 	case "share":
 		if trigger != TriggerTUI {
 			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
@@ -327,7 +327,7 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecu
 			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return *(&CmdExecutionResult{}).SetCodeAndError(CmdShare(timeline, tootId)) //, false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdShare(timeline, tootId))
 	case "?", "help":
 		if trigger != TriggerTUI {
 			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}

--- a/mast/cmd.go
+++ b/mast/cmd.go
@@ -2,6 +2,7 @@ package mast
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"regexp"
@@ -22,9 +23,27 @@ const (
 	CodeUserNotFound                      = 3
 	CodeTriggerNotSupported               = 4
 
-	CodeQuit = -1
-	CodeHelp = -2
+	CodeQuit    = -1
+	CodeHelp    = -2
+	CodeHistory = -3
 )
+
+type CmdExecutionResult struct {
+	retCode        CmdReturnCode
+	err            error
+	reloadTimeline bool
+}
+
+func (i *CmdExecutionResult) SetCodeAndError(retCode CmdReturnCode, err error) *CmdExecutionResult {
+	i.retCode = retCode
+	i.err = err
+
+	return i
+}
+
+func (i *CmdExecutionResult) Decompose() (CmdReturnCode, error, bool) {
+	return i.retCode, i.err, i.reloadTimeline
+}
 
 type CmdTrigger int
 
@@ -86,6 +105,8 @@ func CmdAvailable() []string {
 
 		// "search",
 
+		"history",
+
 		"help",
 		"?",
 
@@ -124,7 +145,7 @@ func CmdAutocompleter(input string, knownUsers map[string]string) []string {
 	return entries
 }
 
-func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) (CmdReturnCode, bool) {
+func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) CmdExecutionResult {
 	split := strings.SplitN(input, " ", 2)
 	cmd := split[0]
 
@@ -136,20 +157,20 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) (CmdRetu
 	switch cmd {
 	case "home":
 		timeline.Switch(TimelineHome, nil)
-		return CodeOk, true
+		return CmdExecutionResult{CodeOk, nil, true}
 	case "local":
 		timeline.Switch(TimelineLocal, nil)
-		return CodeOk, true
+		return CmdExecutionResult{CodeOk, nil, true}
 	case "public":
 		timeline.Switch(TimelinePublic, nil)
-		return CodeOk, true
+		return CmdExecutionResult{CodeOk, nil, true}
 	case "notifications":
 		timeline.Switch(TimelineNotifications, nil)
-		return CodeOk, true
+		return CmdExecutionResult{CodeOk, nil, true}
 	case "hashtag":
 		hashtag, isLocal, err := CmdHelperGetHashtagParams(args)
 		if err != nil {
-			return CodeNotOk, false
+			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
 		timelineOptions := TimelineOptions{
@@ -158,10 +179,11 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) (CmdRetu
 		}
 
 		timeline.Switch(TimelineHashtag, &timelineOptions)
-		return CodeOk, true
+		return CmdExecutionResult{CodeOk, nil, true}
 	case "whois":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
 		var account *mastodon.Account
@@ -176,7 +198,7 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) (CmdRetu
 			accounts, err := timeline.SearchUser(args, 1)
 			if err != nil || len(accounts) < 1 {
 				// TODO: pass info back to caller
-				return CodeUserNotFound, false
+				return CmdExecutionResult{CodeUserNotFound, errors.New(fmt.Sprintf("user %s not found", args)), false}
 			}
 
 			account = accounts[0]
@@ -187,140 +209,148 @@ func CmdProcessor(timeline *Timeline, input string, trigger CmdTrigger) (CmdRetu
 		}
 
 		timeline.Switch(TimelineUser, &timelineOptions)
-		return CodeOk, true
+		return CmdExecutionResult{CodeOk, nil, true}
 	case "t", "toot":
-		return CmdToot(timeline, args, -1, VisibilityPublic), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityPublic)) //false
 	case "tp", "tootprivate":
-		return CmdToot(timeline, args, -1, VisibilityPrivate), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityPrivate)) //, false
 	case "tu", "tootunlisted":
-		return CmdToot(timeline, args, -1, VisibilityUnlisted), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityUnlisted)) //, false
 	case "td", "tootdirect":
-		return CmdToot(timeline, args, -1, VisibilityUnlisted), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, -1, VisibilityUnlisted)) //, false
 	case "re", "reply":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
 		tootId, args, err := CmdHelperGetReplyParams(args)
 		if err != nil {
-			return CodeNotOk, false
+			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return CmdToot(timeline, args, tootId, VisibilityPublic), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityPublic)) //, false
 	case "rep", "replyprivate":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
 		tootId, args, err := CmdHelperGetReplyParams(args)
 		if err != nil {
-			return CodeNotOk, false
+			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return CmdToot(timeline, args, tootId, VisibilityPrivate), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityPrivate)) // false
 	case "reu", "replyunlisted":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
 		tootId, args, err := CmdHelperGetReplyParams(args)
 		if err != nil {
-			return CodeNotOk, false
+			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return CmdToot(timeline, args, tootId, VisibilityUnlisted), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityUnlisted)) // false
 	case "red", "replydirect":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
 		tootId, args, err := CmdHelperGetReplyParams(args)
 		if err != nil {
-			return CodeNotOk, false
+			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return CmdToot(timeline, args, tootId, VisibilityDirect), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdToot(timeline, args, tootId, VisibilityDirect)) // false
 	case "rt", "retoot", "boost":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
 		tootId, err := CmdHelperGetBoostParams(args)
 		if err != nil {
-			return CodeNotOk, false
+			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return CmdBoost(timeline, tootId), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdBoost(timeline, tootId)) //, false
 	case "ut", "unretoot", "unboost":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
 		tootId, err := CmdHelperGetBoostParams(args)
 		if err != nil {
-			return CodeNotOk, false
+			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return CmdUnboost(timeline, tootId), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdUnboost(timeline, tootId)) // false
 	case "fav":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
 		tootId, err := CmdHelperGetFavParams(args)
 		if err != nil {
-			return CodeNotOk, false
+			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return CmdFav(timeline, tootId), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdFav(timeline, tootId)) // false
 	case "unfav":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
 		tootId, err := CmdHelperGetFavParams(args)
 		if err != nil {
-			return CodeNotOk, false
+			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return CmdUnfav(timeline, tootId), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdUnfav(timeline, tootId)) //, false
 	case "open":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
 		tootId, err := CmdHelperGetOpenParams(args)
 		if err != nil {
-			return CodeNotOk, false
+			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return CmdOpen(timeline, tootId), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdOpen(timeline, tootId)) //, false
 	case "share":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
 		tootId, err := CmdHelperGetShareParams(args)
 		if err != nil {
-			return CodeNotOk, false
+			return CmdExecutionResult{CodeNotOk, err, false}
 		}
 
-		return CmdShare(timeline, tootId), false
+		return *(&CmdExecutionResult{}).SetCodeAndError(CmdShare(timeline, tootId)) //, false
 	case "?", "help":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
-		return CodeHelp, false
+		return CmdExecutionResult{CodeHelp, nil, false}
+
+	case "history":
+		if trigger != TriggerTUI {
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
+		}
+
+		return CmdExecutionResult{CodeHistory, nil, false}
+
 	case "quit", "exit", "bye", "q":
 		if trigger != TriggerTUI {
-			return CodeTriggerNotSupported, false
+			return CmdExecutionResult{CodeTriggerNotSupported, nil, false}
 		}
 
-		return CodeQuit, false
+		return CmdExecutionResult{CodeQuit, nil, false}
 	}
 
-	return CodeCommandNotFound, false
+	return CmdExecutionResult{CodeCommandNotFound, nil, false}
 }
 
 func CmdHelperGetHashtagParams(args string) (string, bool, error) {
@@ -386,7 +416,7 @@ func CmdToot(
 	timeline *Timeline,
 	content string,
 	inReplyTo int,
-	visibility string) CmdReturnCode {
+	visibility string) (CmdReturnCode, error) {
 	var status string = ""
 	var spoiler string = ""
 	var sensitive bool = false
@@ -420,49 +450,49 @@ func CmdToot(
 		&spoiler,
 	)
 	if err != nil {
-		return CodeNotOk
+		return CodeNotOk, err
 	}
 
-	return CodeOk
+	return CodeOk, nil
 }
 
-func CmdBoost(timeline *Timeline, tootID int) CmdReturnCode {
+func CmdBoost(timeline *Timeline, tootID int) (CmdReturnCode, error) {
 	_, err := timeline.Boost(tootID, true)
 	if err != nil {
-		return CodeNotOk
+		return CodeNotOk, err
 	}
 
-	return CodeOk
+	return CodeOk, nil
 }
 
-func CmdUnboost(timeline *Timeline, tootID int) CmdReturnCode {
+func CmdUnboost(timeline *Timeline, tootID int) (CmdReturnCode, error) {
 	_, err := timeline.Boost(tootID, false)
 	if err != nil {
-		return CodeNotOk
+		return CodeNotOk, err
 	}
 
-	return CodeOk
+	return CodeOk, nil
 }
 
-func CmdFav(timeline *Timeline, tootID int) CmdReturnCode {
+func CmdFav(timeline *Timeline, tootID int) (CmdReturnCode, error) {
 	_, err := timeline.Fav(tootID, true)
 	if err != nil {
-		return CodeNotOk
+		return CodeNotOk, err
 	}
 
-	return CodeOk
+	return CodeOk, nil
 }
 
-func CmdUnfav(timeline *Timeline, tootID int) CmdReturnCode {
+func CmdUnfav(timeline *Timeline, tootID int) (CmdReturnCode, error) {
 	_, err := timeline.Fav(tootID, false)
 	if err != nil {
-		return CodeNotOk
+		return CodeNotOk, err
 	}
 
-	return CodeOk
+	return CodeOk, nil
 }
 
-func CmdOpen(timeline *Timeline, tootID int) CmdReturnCode {
+func CmdOpen(timeline *Timeline, tootID int) (CmdReturnCode, error) {
 	var cmd *exec.Cmd
 
 	url := timeline.Toots[tootID].Status.URL
@@ -476,25 +506,25 @@ func CmdOpen(timeline *Timeline, tootID int) CmdReturnCode {
 		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
 	default:
 		// errors.New("Platform not supported!")
-		return CodeNotOk
+		return CodeNotOk, errors.New("Platform not supported!")
 	}
 
 	cmd.Env = append(os.Environ())
 	err := cmd.Start()
 	if err != nil {
-		return CodeNotOk
+		return CodeNotOk, err
 	}
 
-	return CodeOk
+	return CodeOk, nil
 }
 
-func CmdShare(timeline *Timeline, tootID int) CmdReturnCode {
+func CmdShare(timeline *Timeline, tootID int) (CmdReturnCode, error) {
 	url := timeline.Toots[tootID].Status.URL
 
 	err := clipboard.WriteAll(url)
 	if err != nil {
-		return CodeNotOk
+		return CodeNotOk, err
 	}
 
-	return CodeOk
+	return CodeOk, nil
 }

--- a/mast/timeline.go
+++ b/mast/timeline.go
@@ -2,6 +2,7 @@ package mast
 
 import (
 	"context"
+	"errors"
 
 	"github.com/mattn/go-mastodon"
 )
@@ -167,6 +168,9 @@ func (timeline *Timeline) Toot(
 	}
 
 	if inReplyTo > -1 {
+		if inReplyTo >= len(timeline.Toots) {
+			return nil, errors.New("Replied-to toot does not exist")
+		}
 		newToot.InReplyToID = timeline.Toots[inReplyTo].Status.ID
 	}
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/atotto/clipboard"
 	"github.com/gdamore/tcell/v2"
+	"github.com/kr/text"
 	"github.com/rivo/tview"
 
 	"github.com/mattn/go-mastodon"
@@ -32,6 +34,7 @@ type TUICore struct {
 	CmdLine *tview.InputField
 	Profile *tview.TextView
 	Stream  *tview.TextView
+	History *History
 	Grid    *tview.Grid
 
 	Prompt string
@@ -77,7 +80,12 @@ func TUI(tuiCore TUICore) {
 				cmd := tuiCore.CmdLine.GetText()
 				tuiCore.CmdLine.SetText("")
 				tuiCore.Progress.Run(func() (mast.CmdReturnCode, bool) {
-					retCode, ok := mast.CmdProcessor(&tuiCore.Timeline, cmd, mast.TriggerTUI)
+
+					result := mast.CmdProcessor(&tuiCore.Timeline, cmd, mast.TriggerTUI)
+
+					retCode, err, reloadTimeline := result.Decompose()
+
+					tuiCore.updateHistory(cmd, retCode, err)
 
 					switch retCode {
 					case mast.CodeOk:
@@ -97,11 +105,13 @@ func TUI(tuiCore TUICore) {
 						tuiCore.UpdateTimeline(true)
 					case mast.CodeHelp:
 						tuiCore.ShowHelp()
+					case mast.CodeHistory:
+						tuiCore.ShowHistory()
 					case mast.CodeQuit:
 						tuiCore.App.Stop()
 					}
 
-					return retCode, ok
+					return retCode, reloadTimeline
 				})
 			}
 		})
@@ -122,6 +132,8 @@ func TUI(tuiCore TUICore) {
 		SetDynamicColors(true).
 		SetRegions(true).
 		SetWrap(true)
+
+	tuiCore.History = NewHistory(&tuiCore)
 
 	tuiCore.Grid = tview.NewGrid().
 		SetRows(8, 0, 1).
@@ -196,6 +208,49 @@ func TUI(tuiCore TUICore) {
 
 	if err := tuiCore.App.SetRoot(tuiCore.Grid, true).Run(); err != nil {
 		panic(err)
+	}
+}
+
+func (tuiCore *TUICore) ShowHistory() {
+	tuiCore.App.SetRoot(tuiCore.History.Root, true)
+}
+
+func (tuiCore *TUICore) updateHistory(cmd string, code mast.CmdReturnCode, err error) {
+	var color tcell.Color
+	var codeString string
+
+	switch code {
+	case mast.CodeOk:
+		codeString = "Ok"
+		color = tcell.ColorGreen
+	case mast.CodeNotOk:
+		codeString = "Not Ok"
+		color = tcell.ColorRed
+	case mast.CodeCommandNotFound:
+		codeString = "Command not found"
+		color = tcell.ColorRed
+		break
+	case mast.CodeUserNotFound:
+		codeString = "User not found"
+		color = tcell.ColorRed
+		break
+	default:
+		return
+	}
+
+	dateTime := time.Now()
+	dateTimeString := fmt.Sprint(dateTime.Format("01-02-2006 15:04:05"))
+
+	row := tuiCore.History.Table.GetRowCount()
+
+	tuiCore.History.Table.SetCell(row, 0, tview.NewTableCell(dateTimeString))
+	tuiCore.History.Table.SetCell(row, 1, tview.NewTableCell(cmd).SetMaxWidth(25))
+	tuiCore.History.Table.SetCell(row, 2, tview.NewTableCell(codeString).SetTextColor(color))
+
+	if err != nil {
+		_, _, width := tuiCore.History.Table.GetCell(0, 3).GetLastPosition()
+		wrapped := text.Wrap(err.Error(), width)
+		tuiCore.History.Table.SetCell(row, 3, tview.NewTableCell(wrapped))
 	}
 }
 
@@ -328,6 +383,7 @@ func (tuiCore *TUICore) ExitCommandMode(force bool) bool {
 }
 
 var spinners = [...]string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
 // var spinners = [...]string{"▁", "▂", "▃", "▄", "▅", "▆", "▇", "█", "▇", "▆", "▅", "▄", "▃"}
 // var spinners = [...]string{"◴", "◷", "◶", "◵"}
 // var spinners = [...]string{"←", "↖", "↑", "↗", "→", "↘", "↓", "↙"}
@@ -372,11 +428,11 @@ func (i *ProgressManager) Run(action func() (mast.CmdReturnCode, bool)) {
 
 	go func() {
 		cmd, _ := action()
-		if cmd == mast.CodeOk{
+		if cmd == mast.CodeOk {
 			cmdResult <- "[green]✓"
 		} else if cmd == mast.CodeNotOk {
 			cmdResult <- "[red]𐄂"
-		}	else {
+		} else {
 			cmdResult <- " "
 		}
 		close(cmdResult)
@@ -416,4 +472,71 @@ func (i *ProgressManager) SetLabel(label string) {
 
 func (i *ProgressManager) updateLabel() {
 	i.inputField.SetLabel(fmt.Sprintf("%s[%s]%s", i.prefix, i.labelColorString, i.label))
+}
+
+type History struct {
+	Root  *tview.Pages
+	Table *tview.Table
+	modal *tview.Modal
+}
+
+func NewHistory(app *TUICore) *History {
+	history := &History{}
+	history.Table = tview.NewTable().
+		SetSelectable(true, true).
+		SetSelectedStyle(tcell.Style{}.Reverse(true)).
+		SetCell(0, 0,
+			tview.NewTableCell("Time").
+				SetAttributes(tcell.AttrBold).
+				SetSelectable(false)).
+		SetCell(0, 1,
+			tview.NewTableCell("Command").
+				SetAttributes(tcell.AttrBold).
+				SetSelectable(false)).
+		SetCell(0, 2,
+			tview.NewTableCell("Status").
+				SetAttributes(tcell.AttrBold).
+				SetAlign(tview.AlignCenter).
+				SetSelectable(false)).
+		SetCell(0, 3,
+			tview.NewTableCell("Descripton").
+				SetAttributes(tcell.AttrBold).
+				SetSelectable(false).
+				SetExpansion(1)).
+		SetBorders(true).
+		SetSelectedFunc(func(x, y int) {
+			if y != 0 {
+				_, _, width, _ := app.Stream.Box.GetInnerRect()
+				history.modal.SetRect(0, 0, width, 15)
+				cell := history.Table.GetCell(x, y)
+				history.modal.SetText(cell.Text)
+				history.modal.SetFocus(0)
+				history.Root.SendToFront("modal")
+				history.Root.ShowPage("modal")
+			}
+		}).
+		SetDoneFunc(func(key tcell.Key) {
+			if key == tcell.KeyEscape {
+				app.App.SetRoot(app.Grid, true)
+				app.EnterCommandMode()
+			}
+		})
+
+	history.modal = tview.NewModal().
+		SetButtonTextColor(tcell.ColorWhite). // this shouldnt be required but tview seems to have a bug where button background doesnt visibly update if PrimaryTextColor is ColorDefault
+		AddButtons([]string{"Close", "Copy to Clipboard"}).
+		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+			if buttonLabel == "Copy to Clipboard" {
+				clipboard.WriteAll(history.Table.GetCell(history.Table.GetSelection()).Text)
+			} else {
+				history.Root.HidePage("modal")
+				history.Root.SendToBack("modal")
+			}
+		})
+
+	history.Root = tview.NewPages().
+		AddPage("background", history.Table, true, true).
+		AddPage("modal", history.modal, true, false)
+
+	return history
 }


### PR DESCRIPTION
Adds :history function that shows a table of the last 100 commands and their results.  Cell contents are expandable into a modal on enter with an option to copy to the clipboard (useful for re-sending failed messages)