### PR TITLE
ux improvements + crash fix

### DIFF
--- a/tui/text.go
+++ b/tui/text.go
@@ -29,6 +29,7 @@ func CreateLine(
 	}
 
 	// allocate each justified space to one of the spaces in the list at random
+	rand.Seed(112358132134) // consistent seed so that results are the same between reloads
 	for i := leftoverSpaces; i > 0; i-- {
 		selection := rand.Intn(numberOfSpaces)
 		*spaceList[selection] += " "


### PR DESCRIPTION
* consistent seeds for justification so that reloads of the same content produce the same strings
* prevent entering of `:` when it would be the first character in command mode
* prevent automatic refresh from scrolling to end of content (unless its the first load)
* run periodic refresh through progress code and enforce only one progress operation at a time.  This has ux implications but also fixes an intermittent crash where the refresh happens during the act of drawing the content of a manual command.  Toots are swapped out during iteration and boom.