### PR TITLE
Support user images

### DIFF
--- a/cli/cmdCmd.go
+++ b/cli/cmdCmd.go
@@ -27,9 +27,19 @@ var cmdCmd = &cobra.Command{
 		cmdReturn, _, loadTimeline := result.Decompose()
 		switch cmdReturn {
 		case mast.CodeOk:
+			var imageCache *tui.Images
+			var err error
+			if flagShowImages || flagShowUserImages {
+				imageCache, err = tui.NewImages(tempDir)
+				if err != nil {
+					fmt.Print("Cannot create image cache. Select a different directory or run with --show-images=false and --show-user-images=false")
+					os.Exit(1)
+				}
+			}
+
 			if loadTimeline == true {
 				timeline.Load()
-				output, err := tui.RenderTimeline(&timeline, 72, flagShowImages, flagJustifyText)
+				output, err := tui.RenderTimeline(&timeline, imageCache, 72, flagShowImages, flagShowUserImages, flagJustifyText)
 				if err != nil {
 					panic(err)
 				}

--- a/cli/rootCmd.go
+++ b/cli/rootCmd.go
@@ -11,7 +11,9 @@ import (
 var help string
 var server string
 var accessToken string
+var tempDir string
 var flagShowImages bool
+var flagShowUserImages bool
 var flagJustifyText bool
 
 // var clientID string
@@ -57,12 +59,29 @@ func init() {
 		"Show images in timeline",
 	)
 	rootCmd.PersistentFlags().BoolVarP(
+		&flagShowUserImages,
+		"show-user-images",
+		"u",
+		true,
+		"Show user images",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&tempDir,
+		"temp-dir",
+		"",
+		"Temporary director for image cache.  Default is the system default temporary directory",
+	)
+	rootCmd.PersistentFlags().BoolVarP(
 		&flagJustifyText,
 		"justify-text",
 		"j",
 		true,
 		"Justify text in timeline",
 	)
+
+	if tempDir == "" {
+		tempDir = os.TempDir()
+	}
 }
 
 func initConfig() {

--- a/cli/tuiCmd.go
+++ b/cli/tuiCmd.go
@@ -16,6 +16,8 @@ var tuiCmd = &cobra.Command{
 			Client: MastodonClient,
 			Options: tui.TUIOptions{
 				ShowImages:     flagShowImages,
+				ShowUserImages: flagShowUserImages,
+				TempDir:        tempDir,
 				AutoCompletion: flagAutocompletion,
 				JustifyText:    flagJustifyText,
 			},

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/dlclark/regexp2 v1.7.0 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/gdamore/tcell v1.4.0 // indirect
+	github.com/google/btree v1.0.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
@@ -37,6 +38,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-tty v0.0.3 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/peterbourgon/diskv/v3 v3.0.1 // indirect
 	github.com/prometheus/tsdb v0.7.1 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
 	github.com/russross/blackfriday v2.0.0+incompatible // indirect
@@ -57,4 +59,5 @@ require (
 	golang.org/x/term v0.2.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
 	gopkg.in/resty.v1 v1.12.0 // indirect
+	rsc.io/cloud v0.0.0-20150601041429-b8f75868019f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,7 @@ github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -411,6 +412,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/peterbourgon/diskv/v3 v3.0.1 h1:x06SQA46+PKIUftmEujdwSEpIx8kR+M9eLYsUxeYveU=
+github.com/peterbourgon/diskv/v3 v3.0.1/go.mod h1:kJ5Ny7vLdARGU3WUuy6uzO6T0nb/2gWcT1JiBvRmb5o=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
@@ -1023,5 +1026,7 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+rsc.io/cloud v0.0.0-20150601041429-b8f75868019f h1:7xf0hPWNAu3fUfa5vW5Eno6V85RHjE6xQugJFvFa97g=
+rsc.io/cloud v0.0.0-20150601041429-b8f75868019f/go.mod h1:vhUu6wrfbJM1SFfQmUjA6UsCclGbKioGq7LBCLCnMcA=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/tui/images.go
+++ b/tui/images.go
@@ -1,0 +1,107 @@
+package tui
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/gob"
+	"fmt"
+	"image/color"
+	"strings"
+
+	"github.com/peterbourgon/diskv/v3"
+
+	"github.com/eliukblau/pixterm/pkg/ansimage"
+)
+
+type Images struct {
+	diskCache *diskv.Diskv
+}
+
+func cacheKey(url string, y int, x int) string {
+	sha := sha256.New()
+	sha.Write([]byte(url))
+
+	return fmt.Sprintf("%x-%d-%d", sha.Sum(nil), y, x)
+}
+
+func NewImages(directory string) (*Images, error) {
+	images := &Images{}
+
+	transform := func(s string) []string {
+		parts := []string{}
+		parts = append(parts, string(s[0:2]))
+		parts = append(parts, string(s[2:4]))
+		return parts
+	}
+
+	images.diskCache = diskv.New(diskv.Options{
+		BasePath:     directory,
+		Transform:    transform,
+		CacheSizeMax: 1024 * 1024,
+	})
+
+	test := make([]string, 1)
+	test[0] = "test"
+	err := images.saveToDiskCache("test", &test)
+	if err != nil {
+		return nil, err
+	} else {
+		return images, nil
+	}
+}
+
+func (i *Images) loadFromDiskCache(key string) (*[]string, error) {
+	cacheStream, err := i.diskCache.ReadStream(key, false)
+	if err != nil {
+		return nil, err
+	}
+
+	var storedSlices []string
+	gob.NewDecoder(cacheStream).Decode(&storedSlices)
+	return &storedSlices, nil
+}
+
+func (i *Images) saveToDiskCache(key string, data *[]string) error {
+	var inputBuffer bytes.Buffer
+	gob.NewEncoder(&inputBuffer).Encode(data)
+	return i.diskCache.Write(key, inputBuffer.Bytes())
+}
+
+func (i *Images) ImageAtSize(url string, y int, x int, afterLoad func(loaded *[]string) *[]string) *[]string {
+	if afterLoad == nil {
+		afterLoad = func(loaded *[]string) *[]string {
+			return loaded
+		}
+	}
+	key := cacheKey(url, y, x)
+
+	cachedSlice, err := i.loadFromDiskCache(key)
+	if err == nil {
+		return afterLoad(cachedSlice)
+	}
+
+	pix, err := ansimage.NewScaledFromURL(
+		url,
+		y,
+		x,
+		color.Transparent,
+		ansimage.ScaleModeResize,
+		ansimage.NoDithering,
+	)
+
+	if err == nil {
+		imageString := pix.RenderExt(false, false)
+		split := strings.Split(imageString, "\n")
+		i.saveToDiskCache(key, &split)
+
+		return afterLoad(&split)
+	} else {
+		placeholder := make([]string, 0)
+		for i := 0; i < y; i++ {
+			placeholder = append(placeholder, strings.Repeat("?", x))
+		}
+		i.saveToDiskCache(key, &placeholder)
+
+		return afterLoad(&placeholder)
+	}
+}

--- a/tui/text.go
+++ b/tui/text.go
@@ -4,9 +4,100 @@ import (
 	"container/list"
 	"math"
 	"math/rand"
+	"strings"
 
 	"github.com/mattn/go-runewidth"
 )
+
+type Indent struct {
+	Width int
+	Lines []string
+}
+
+func Max(x, y int) int {
+	if x > y {
+		return x
+	}
+	return y
+}
+
+func Min(x, y int) int {
+	if x > y {
+		return y
+	}
+	return x
+}
+
+func (x *Indent) InitializeWithString(width int, line string) {
+	var lines = make([]string, 1)
+	lines[0] = line
+	x.InitializeWithArray(width, lines)
+}
+
+func (x *Indent) InitializeWithArray(width int, lines []string) {
+	x.Width = width
+	x.Lines = lines // TODO: validation?
+}
+
+func (x *Indent) GetLine(line int) string {
+	if line < len(x.Lines) {
+		return x.Lines[line]
+	} else {
+		return strings.Repeat(" ", x.Width)
+	}
+}
+
+func (x *Indent) IndentSlice(lines *[]string) *[]string {
+	numberOfLines := Max(len(x.Lines), len(*lines))
+	var newLines []string = make([]string, 0)
+	r := 0
+	for r < numberOfLines {
+		line := ""
+		if len(x.Lines) <= r {
+			line = x.Lines[len(x.Lines)-1]
+		} else {
+			line = x.Lines[r]
+		}
+
+		if len(*lines) <= r {
+			line += strings.Repeat(" ", 1)
+		} else {
+			line += (*lines)[r]
+		}
+		newLines = append(newLines, line)
+		r++
+	}
+	return &newLines
+}
+
+func (x *Indent) ExtendWithIndent(with Indent) *Indent {
+	// this method will access the variable
+	// food in Animal class
+	numberOfLines := Max(len(x.Lines), len(with.Lines))
+	indent := &Indent{
+		Width: x.Width + with.Width,
+		Lines: make([]string, numberOfLines),
+	}
+	r := 0
+	for r < numberOfLines {
+		line := ""
+		if len(x.Lines) <= r {
+			line = strings.Repeat(" ", x.Width)
+		} else {
+			line = x.Lines[r]
+		}
+
+		if len(with.Lines) <= r {
+			line += strings.Repeat(" ", with.Width)
+		} else {
+			line += with.Lines[r]
+		}
+
+		indent.Lines[r] = line
+		r++
+	}
+	return indent
+}
 
 func StringPtr(s string) *string {
 	return &s
@@ -53,34 +144,36 @@ func CreateLine(
 func WrapWithIndent(
 	stringToWrap string,
 	maximumWidth int,
-	indentString string,
 	justifyText bool,
-) string {
+) *[]string {
 
 	// list of words that will be written to the current line
 	wordList := list.New()
+	// current line we're on
+	lineCount := 0
 	// number of pre-justified spaces that will be present in the current line
 	spaceCount := 0
 	// number of characters that have already been committed to the current line
 	committedCharacterCount := 0
 	characterCountOfCurrentWord := 0
 
-	out := indentString
+	var outList []string // = make([]string, 1)
 	word := ""
 	for _, character := range stringToWrap {
 		characterWidth := runewidth.RuneWidth(character)
 		if character == '\n' || character == '\r' {
 			if characterCountOfCurrentWord+committedCharacterCount >= maximumWidth {
-				out += "\n"
-				out += indentString
+				line := CreateLine(*wordList, 0, 0)
+				outList = append(outList, line)
+				lineCount++
+				wordList = list.New()
 			}
 			wordList.PushBack(word)
 
 			// lines that end with a newline don't get justified
 			line := CreateLine(*wordList, 0, 0)
-			out += line
-			out += "\n"
-			out += indentString
+			outList = append(outList, line)
+			lineCount++
 
 			// reset all vars to new line
 			word = ""
@@ -126,9 +219,8 @@ func WrapWithIndent(
 
 			// commit the line
 			line := CreateLine(*wordList, spaceCount, leftoverSpace)
-			out += line
-			out += "\n"
-			out += indentString
+			outList = append(outList, line)
+			lineCount++
 
 			// reset line vars
 			spaceCount = 0
@@ -142,8 +234,9 @@ func WrapWithIndent(
 	}
 
 	// dump what's left
+	wordList.PushBack(word)
 	line := CreateLine(*wordList, 0, 0)
-	out += line
-	out += word
-	return out
+	outList = append(outList, line)
+
+	return &outList
 }

--- a/tui/timeline.go
+++ b/tui/timeline.go
@@ -8,8 +8,10 @@ import (
 
 func RenderTimeline(
 	timeline *mast.Timeline,
+	imageCache *Images,
 	width int,
 	showImages bool,
+	showUserImages bool,
 	justifyText bool) (string, error) {
 	var output string = ""
 	var err error = nil
@@ -17,8 +19,14 @@ func RenderTimeline(
 	var tootOutput string = ""
 	newRenderedIndex := len(timeline.Toots)
 	for i := (timeline.LastRenderedIndex + 1); i < newRenderedIndex; i++ {
-		tootOutput, err = RenderToot(&timeline.Toots[i], width, showImages, justifyText)
-		output = fmt.Sprintf("%s%s\n", output, tootOutput)
+		if i == timeline.LastRenderedIndex+1 {
+			output += "\n"
+		}
+		tootOutput, err = RenderToot(&timeline.Toots[i], imageCache, width, showImages, showUserImages, justifyText)
+		output = fmt.Sprintf("%s%s", output, tootOutput)
+		if i != newRenderedIndex-1 {
+			output += "\n"
+		}
 	}
 
 	timeline.LastRenderedIndex = (newRenderedIndex - 1)


### PR DESCRIPTION
Support cached images + user images as well as a more configurable indentation model that should hopefully make any future changes with respect to indentation a bit easier to manage.  I would like to make the vertical line introduced for separating toot #s/images link up to the outside frame via `┴` and `┬` but that modification to tview may require a whole new container implementation.  That's an exercise for later 😅